### PR TITLE
Fix typo in attributes

### DIFF
--- a/XcodeML-F/DefsDecls.tex
+++ b/XcodeML-F/DefsDecls.tex
@@ -185,7 +185,7 @@ The {\tt FmoduleDefinition} element represents a {\tt module} statement.
 {Specified the module name.}{R}
 \XcodeMLAttrDef{is\_sub}{bool}
 {{\tt true} if the element represents a submodule.}{O}
-\XcodeMLAttrDef{parenet\_name}{text}
+\XcodeMLAttrDef{parent\_name}{text}
 {Specifies the name of the parent module.}{O}
 \end{XcodeMLAttributes}
 
@@ -365,5 +365,3 @@ The {\tt FimportDecl} element represents an {\tt import} statement.
 \XcodeMLAttrDef{common attributes}{-}
 {Refer to "\ref{sec:Commonattributesofdefinition} Common attributes of the definition / declaration / statement element".}{-}
 \end{XcodeMLAttributes}
-
-

--- a/XcodeML-F/General.tex
+++ b/XcodeML-F/General.tex
@@ -106,7 +106,7 @@ The {\tt value} element represents an arbitrary value expressed by an expression
 \end{XcodeMLChildElements}
 
 \begin{XcodeMLAttributes}
-\XcodeMLAttrDef{repeat\_counttyp}{text}
+\XcodeMLAttrDef{repeat\_count}{text}
 {Specifies the repeat count of the element.
  Valid only in the initialization expression of the {\tt data} statement.}{O}
 \end{XcodeMLAttributes}
@@ -453,5 +453,3 @@ The {\tt varList} element represents a list.
 \XcodeMLAttrDef{name}{text}
 {Specifies the {\tt namelist} group name if the parent is the {\tt FnamelistDecl} element.}{O}
 \end{XcodeMLAttributes}
-
-


### PR DESCRIPTION
Just fix the misspelling of two attributes