### PR TITLE
Add missing FenumDecl in specs.

### DIFF
--- a/XcodeML-F/DefsDecls.tex
+++ b/XcodeML-F/DefsDecls.tex
@@ -365,3 +365,22 @@ The {\tt FimportDecl} element represents an {\tt import} statement.
 \XcodeMLAttrDef{common attributes}{-}
 {Refer to "\ref{sec:Commonattributesofdefinition} Common attributes of the definition / declaration / statement element".}{-}
 \end{XcodeMLAttributes}
+
+
+\subsection{ {\tt FenumDecl} element}
+
+The {\tt FenumDecl} element represents an {\tt enum} statement.
+
+\XcodeMLContentsModel{ empty }
+
+\begin{XcodeMLChildElements}
+  \XcodeMLElementDef{-}
+  {-}{-}
+\end{XcodeMLChildElements}
+
+\begin{XcodeMLAttributes}
+\XcodeMLAttrDef{type}{text}
+{Specifies the type name identifier in XcodeML/Fortran.}{R}
+\XcodeMLAttrDef{common attributes}{-}
+{Refer to "\ref{sec:Commonattributesofdefinition} Common attributes of the definition / declaration / statement element".}{-}
+\end{XcodeMLAttributes}


### PR DESCRIPTION
See https://github.com/omni-compiler/omni-compiler/issues/222

Has been introduces in the compiler front-end and back-end but not in the spec. 