### PR TITLE
Add imported_id attribute

### DIFF
--- a/XcodeML-F/Common.tex
+++ b/XcodeML-F/Common.tex
@@ -32,6 +32,9 @@ Every definition, declaration and statement elements may have the following attr
 {Specifies the line number in the Fortran program.}{R}
 \XcodeMLAttrDef{file}{text}
 {Specifies the source code name of the Fortran program.}{R}
+\XcodeMLAttrDef{imported\_id}{text}
+{Specifies the original type id imported from use statement. Used to track element imported 
+across several translation unit.}{O}
 \end{XcodeMLAttributes}
 
 


### PR DESCRIPTION
Following PR omni-compiler/xcodeml-tools#8 `imported_id` is added to the specification