### PR TITLE
Modification of binary operator according to issue xcodeml-tools#96

### DIFF
--- a/XcodeML-F/Expression.tex
+++ b/XcodeML-F/Expression.tex
@@ -455,6 +455,9 @@ The elements representing the binary operators are described below.
 \XcodeMLAttrDef{type}{text}
 {Specifies the type name identifier in XcodeML/Fortran.
  Refer to "\ref{sec:Thedatatypenameidentifier} The data type name identifier".}{O}
+\XcodeMLAttrDef{is_symbol}{bool} 
+{Specifies if the logical operator are written with the symbol 
+(>, <, =, ==, /=, >=, <=).}{O}
 \end{XcodeMLAttributes}
 
 


### PR DESCRIPTION
* Adding new attribute `is_symbol` to binary operator elements. 

Discussions: --> omni-compiler/xcodeml-tools#96